### PR TITLE
Add setup guide for fund template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 *.zip
 dist/
 build/
+site/
 
 # Python venvs
 .venv/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Public handbook (MkDocs) + internal-only area + policies-as-code + CI guardrails
 5. Use Issue templates for board agendas, IC memos, resolutions.
 6. Before onboarding **any outside capital**, read `COMPLIANCE/MIS_AFSL_Boundary_Note.md` and get advice.
 7. (Optional) Consider ACNC path later; see `COMPLIANCE/ACNC_Option_Note.md`.
+8. Follow `docs/setup.md` for a chronological setup covering ASIC, banking, Stripe and GitHub.
 
 ## Layout
 - `/docs` – public handbook (GitHub Pages)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # <<FUND_NAME>> Handbook
 
-Public handbook for how the fund operates. Internal documents are kept in `/INTERNAL` and are **not** published.
+Public handbook for how the fund operates. Signed contracts and private records are kept off the public site.
 
 !!! note "Mission-lock"
     No distributions to insiders. All returns are **reinvested** into innovation.

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,2 +1,2 @@
 # Legal Overview
-Public summary of structure. Full, signed documents live in `/INTERNAL/contracts`. Skeletons and mission-lock clauses are in `/LEGAL`.
+Public summary of structure. Full, signed documents are stored privately. Skeletons and mission-lock clauses are in `/LEGAL`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,17 @@
+# Setup Guide
+
+Steps to convert this template into an operating, mission-locked fund.
+
+> ⚠️ Not legal or financial advice. Confirm every step with Australian counsel and an accountant.
+
+1. Replace `<<FUND_NAME>>` and other placeholders.
+2. Register a corporate trustee (Pty Ltd) with ASIC and appoint directors.
+3. Execute the trust deed using the templates in `/LEGAL`, embedding the mission-lock.
+4. Obtain ABN and TFN for the trust and the trustee company.
+5. Open a bank account in the trust's name; keep trustee and personal funds separate.
+6. Set up Stripe or another payment processor using the trust's details.
+7. Push this repo to GitHub, enable branch protection and GitHub Pages.
+8. Capture policies and board resolutions in `/POLICIES` and `/GOVERNANCE`.
+9. Begin deploying the fund's own capital only and reinvest all returns.
+
+Share this handbook with advisers for review, then iterate as the fund evolves.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ theme:
   name: material
 nav:
   - Home: index.md
+  - Setup: setup.md
   - Governance:
     - Board Charter: governance/board_charter.md
     - Conflicts Policy: governance/conflicts.md


### PR DESCRIPTION
## Summary
- add step-by-step setup guide for turning the template into an operating mission-locked fund
- expose the new guide in MkDocs navigation and README quickstart

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c49f22dbcc832e823c968daf493a26